### PR TITLE
Export a PLY after LichtFeld CLI training

### DIFF
--- a/gui/steps/training_backends.py
+++ b/gui/steps/training_backends.py
@@ -438,6 +438,8 @@ def build_lichtfeld_training_cmd(options: LichtFeldTrainingOptions) -> list[str]
         "--config",
         str(options.config_path),
         "--train",
+        "--export",
+        "ply",
     ]
     if output_name:
         cmd.extend(["--output-name", output_name])

--- a/tests/test_training_backends.py
+++ b/tests/test_training_backends.py
@@ -159,6 +159,8 @@ def test_lichtfeld_config_overrides_visible_training_parameters(tmp_path: Path) 
         "--config",
         str(options.config_path),
         "--train",
+        "--export",
+        "ply",
         "--no-splash",
         "--headless",
     ]
@@ -271,6 +273,7 @@ def test_lichtfeld_command_includes_dataset_cli_overrides(tmp_path: Path) -> Non
 
     cmd = build_lichtfeld_training_cmd(options)
 
+    assert cmd[cmd.index("--export") + 1] == "ply"
     assert cmd[cmd.index("--output-name") + 1] == "scene_final"
     assert cmd[cmd.index("--resize_factor") + 1] == "2"
     assert cmd[cmd.index("--max-width") + 1] == "0"


### PR DESCRIPTION
Step 6 exposes an `Output PLY Name` and guards that target against overwrite, but the generated LichtFeld command only passes `--train`. A successful headless run therefore creates `project.licht` without the expected PLY.

This change adds `--export ply` to the LichtFeld command so the configured output name is actually written after training. Command-generation tests now require the export arguments.

Validation performed locally:

- Verified the generated command contains `--train --export ply --output-name <name>`.
- Confirmed against LichtFeld Studio that training followed by export creates a valid PLY.
- The resulting test model contained 1,000,000 vertices and SH degree 3.
- `git diff --check` passed.